### PR TITLE
SCCPPGHA-15 Use unified sonarqube-scan-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }} # Put the name of your token here
         with:
+          # Set the property "sonar.cfamily.compile-commands" to the compilation database file
           args: >
-            # Set the property "sonar.cfamily.compile-commands" to the compilation database file
             --define sonar.cfamily.compile-commands=build/compile_commands.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Install sonar-scanner
-        uses: sonarsource/sonarcloud-github-c-cpp@v3
       - name: Install Ninja
         run: |
           wget https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
@@ -33,10 +31,12 @@ jobs:
           -DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS=clang-scan-deps-${{env.CLANG_VERSION}}
           # The project needs to be built so the `.modmap` files are generated 
           cmake --build build --target all
-      - name: Run sonar-scanner
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }} # Put the name of your token here
-        run: |
-          # Set the property "sonar.cfamily.compile-commands" to the compilation database file
-          sonar-scanner --define sonar.cfamily.compile-commands=build/compile_commands.json
+        with:
+          args: >
+            # Set the property "sonar.cfamily.compile-commands" to the compilation database file
+            --define sonar.cfamily.compile-commands=build/compile_commands.json

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-= C++ example project scanned on SonarCloud using compilation database (compile_commands.json)
+= C++ example project scanned on SonarQube Cloud using compilation database (compile_commands.json)
 // URIs:
 :uri-qg-status: https://sonarcloud.io/dashboard?id=sonarsource-cfamily-examples_linux-cmake-compdb-gh-actions-sc
 :img-qg-status: https://sonarcloud.io/api/project_badges/measure?project=sonarsource-cfamily-examples_linux-cmake-compdb-gh-actions-sc&metric=alert_status
@@ -8,27 +8,27 @@
 image:{img-build-status}[Build Status, link={uri-build-status}]
 image:{img-qg-status}[Quality Gate Status,link={uri-qg-status}]
 
-*This project is analysed on https://sonarcloud.io/dashboard?id=sonarsource-cfamily-examples_linux-cmake-compdb-gh-actions-sc[SonarCloud]!*
+*This project is analysed on https://sonarcloud.io/dashboard?id=sonarsource-cfamily-examples_linux-cmake-compdb-gh-actions-sc[SonarQube Cloud]!*
 
 
-It is very easy to analyze a C, C++ and Objective-C project with SonarCloud and https://docs.sonarcloud.io/getting-started/github/[GitHub Actions] using compilation database:
+It is very easy to analyze a C, C++ and Objective-C project with SonarQube Cloud and https://docs.sonarsource.com/sonarqube-cloud/getting-started/github/[GitHub Actions] using compilation database:
 
 . Create a `sonar-project.properties` file to store your configuration
 . In your `.github/workflows/build.yml` file:
-.. Install the Sonar Scanner using https://github.com/SonarSource/sonarcloud-github-c-cpp[SonarCloud C and C++ Github Action]
 .. Generate the compilation database file (set `CMAKE_EXPORT_COMPILE_COMMANDS` to `ON`)
-.. Run `sonar-scanner` with the property `sonar.cfamily.compile-commands` set to your compilation database file
+.. Run the SonarQube scan using https://github.com/SonarSource/sonarqube-scan-action[the SonarSource/sonarqube-scan-action action] with the property `sonar.cfamily.compile-commands` set to your compilation database file
 . Ensure that your token is stored as a secret in your repository (`SONARCLOUD_TOKEN` in this example project). You can request new tokens using https://sonarcloud.io/account/security/[Account/Security page].
 
 You can take a look at the link:sonar-project.properties[sonar-project.properties] and link:.github/workflows/build.yml[build.yml] to see it in practice.
 
 = Documentation
 
-- https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/[Documentation overview of the C, C++ and Objective-C analyzer]
-- https://docs.sonarcloud.io/getting-started/github/[Documentation of using SonarCloud with GitHub]
-- https://docs.sonarcloud.io/advanced-setup/ci-based-analysis/github-actions-for-sonarcloud/[GitHub Action for C and C++ usage]
-- https://docs.sonarcloud.io/advanced-setup/languages/c-family/prerequisites/#generating-a-compilation-database[Generating a compilation database (compile_commands.json)]
-- https://docs.sonarsource.com/sonarcloud/advanced-setup/languages/c-family/running-the-analysis/[Running the analysis in Compilation Database mode]
+- https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/languages/c-family/overview/[C/C++/Objective-C analysis overview]
+- https://docs.sonarsource.com/sonarqube-cloud/getting-started/github/[Getting started with GitHub]
+- https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/ci-based-analysis/github-actions-for-sonarcloud/[Analyze your repository with GitHub Actions]
+- https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/languages/c-family/prerequisites/#generating-a-compilation-database[Generating a compilation database]
+- https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/languages/c-family/running-the-analysis/[Running the CFamily analysis]
+
 
 = Linux\CMake
 
@@ -46,7 +46,7 @@ make
 An example of a flawed C++ code. The https://github.com/sonarsource-cfamily-examples/code[code repository] can be https://github.com/sonarsource-cfamily-examples/automatic-analysis-sc[analyzed automatically], but it can also be compiled with different build systems using different CI pipelines on Linux, macOS, and Windows.
 
 The https://github.com/sonarsource-cfamily-examples/code[code repository] is forked into other repositories in https://github.com/sonarsource-cfamily-examples[this collection] to add a specific build system, platform, and CI.
-The downstream repositories are analyzed either with https://www.sonarqube.org/[SonarQube] or https://sonarcloud.io/[SonarCloud].
+The downstream repositories are analyzed either with https://www.sonarqube.org/[SonarQube Server] or https://sonarcloud.io/[SonarQube Cloud].
 
 You can find examples for:
 
@@ -73,8 +73,8 @@ Running on the following CI services:
 
 Configured for analysis on:
 
-* https://github.com/sonarsource-cfamily-examples?q=-sq[SonarQube]
-* https://github.com/sonarsource-cfamily-examples?q=-sc[SonarCloud]
+* https://github.com/sonarsource-cfamily-examples?q=-sq[SonarQube Server]
+* https://github.com/sonarsource-cfamily-examples?q=-sc[SonarQube Cloud]
 
 You can find also a few examples demonstrating:
 


### PR DESCRIPTION
The [`sonarqube-scan-action@v4.2`](https://github.com/SonarSource/sonarqube-scan-action/releases/tag/v4.2.1) GHA now handles C, C++, and Objective-C projects even when Build Wrapper is needed, replacing `sonarcloud-github-c-cpp`.

This PR makes the replacement.
