### PR TITLE
Fix workflow on Ubuntu 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Install Ninja
-        run: |
-          wget https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
-          sudo unzip ninja-linux.zip -d /usr/local/bin
       - name: Install clang
         run: |
           sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" ${{env.CLANG_VERSION}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: Build
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
   pull_request:
     types: [opened, synchronize, reopened]
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: Build
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
 env:


### PR DESCRIPTION
The GitHub runner image already includes Ninja now; We don't need to install it on our side. See actions/runner-images#11761.